### PR TITLE
Fix: Small correction in Docs

### DIFF
--- a/docs/examples/02-payments.en.md
+++ b/docs/examples/02-payments.en.md
@@ -22,6 +22,7 @@ The response to the request will contain the `Payment` object with the current s
 ```go
 import (
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
+	"github.com/rvinnie/yookassa-sdk-go/yookassa/common"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
@@ -32,7 +33,7 @@ func main() {
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Create a payment
 	payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
-		Amount: &yoopayment.Amount{
+		Amount: &yoocommon.Amount{
 			Value:    "1000.00",
 			Currency: "RUB",
 		},


### PR DESCRIPTION
если использовать тот образец, который указан в доках, то запуск моего тестового проекта падает:
<img width="393" height="54" alt="Screenshot from 2025-09-08 10-24-22" src="https://github.com/user-attachments/assets/893f69f5-adf6-4307-b849-ece6a650fd29" />
Если исправить на вот так (Cursor подсказал, я только-только учусь с Go), то работает видимо нормально, по крайне мере ответ от Юкассы получаю