### PR TITLE
Refactor YooKassa SDK API to context-aware handlers and configurable HTTP client options

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -21,10 +21,20 @@ import "github.com/rvinnie/yookassa-sdk-go/yookassa"
 ```
 2. Configure a Client
 ```golang
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+    "net/http"
+    "time"
+
+    "github.com/rvinnie/yookassa-sdk-go/yookassa"
+    yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
+)
 
 func main() {
-    client := yookassa.NewClient('<Account Id>', '<Secret Key>')	
+    client := yookassa.NewClient(
+        '<Account Id>',
+        '<Secret Key>',
+        yooopts.WithHTTPClient(http.Client{Timeout: 30 * time.Second}),
+    )
 }
 ```
 3. Call the required API method. [More details in our documentation for the YooKassa API](https://yookassa.ru/developers/api?lang=en)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ import "github.com/rvinnie/yookassa-sdk-go/yookassa"
 ```
 2. Установите данные для конфигурации
 ```golang
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+    "net/http"
+    "time"
+
+    "github.com/rvinnie/yookassa-sdk-go/yookassa"
+    yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
+)
 
 func main() {
-    client := yookassa.NewClient('<Идентификатор магазина>', '<Секретный ключ>')	
+    client := yookassa.NewClient(
+        '<Идентификатор магазина>',
+        '<Секретный ключ>',
+        yooopts.WithHTTPClient(http.Client{Timeout: 30 * time.Second}),
+    )
 }
 ```
 3. Вызовите нужный метод API. [Подробнее в документации к API ЮKassa](https://yookassa.ru/developers/api)
@@ -46,6 +56,5 @@ func main() {
 #### [Работа с вебхуками](https://github.com/rvinnie/yookassa-sdk-go/blob/main/docs/examples/04-webhooks.md)
 * [Пример обработки вебхуков](https://github.com/rvinnie/yookassa-sdk-go/blob/main/docs/examples/04-webhooks.md#Пример-обработки-вебхуков)
 * [Тестирование локально](https://github.com/rvinnie/yookassa-sdk-go/blob/main/docs/examples/04-webhooks.md#Тестирование-локально)
-
 
 

--- a/docs/examples/01-configuration.en.md
+++ b/docs/examples/01-configuration.en.md
@@ -10,10 +10,20 @@
 To work with the API, you need to create a client, specifying the store ID and secret key.
 
 ```go
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+    "net/http"
+    "time"
+
+    "github.com/rvinnie/yookassa-sdk-go/yookassa"
+    yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
+)
 
 func main() {
-    client := yookassa.NewClient('<Store ID>', '<Secret key>')	
+    client := yookassa.NewClient(
+        '<Store ID>',
+        '<Secret key>',
+        yooopts.WithHTTPClient(http.Client{Timeout: 30 * time.Second}),
+    )
 }
 ```
 
@@ -24,7 +34,11 @@ func main() {
 After setting the configuration, you can check the correctness of the data, as well as get information about the store.
 
 ```go
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+    "context"
+
+    "github.com/rvinnie/yookassa-sdk-go/yookassa"
+)
 
 func main() {
     // Create a yookassa client by specifying the store ID and secret key
@@ -32,7 +46,7 @@ func main() {
     // Create a settings handler
 	settingsHandler := yookassa.NewSettingsHandler(yooclient)
     // Get information about store or gateway settings
-	settings, _ := settingsHandler.GetAccountSettings(nil)
+	settings, _ := settingsHandler.GetAccountSettings(context.Background(), nil)
 }
 ```
 As a result, we will see something like this:

--- a/docs/examples/01-configuration.md
+++ b/docs/examples/01-configuration.md
@@ -10,10 +10,20 @@
 Для работы с API необходимо создать клиента, указав идентификатор магазина и секретный ключ.
 
 ```go
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+    "net/http"
+    "time"
+
+    "github.com/rvinnie/yookassa-sdk-go/yookassa"
+    yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
+)
 
 func main() {
-    client := yookassa.NewClient('<Идентификатор магазина>', '<Секретный ключ>')	
+    client := yookassa.NewClient(
+        '<Идентификатор магазина>',
+        '<Секретный ключ>',
+        yooopts.WithHTTPClient(http.Client{Timeout: 30 * time.Second}),
+    )
 }
 ```
 
@@ -24,7 +34,11 @@ func main() {
 После установки конфигурации можно проверить корректность данных, а также получить информацию о магазине.
 
 ```go
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+    "context"
+
+    "github.com/rvinnie/yookassa-sdk-go/yookassa"
+)
 
 func main() {
     // Создаем yookassa клиента, указав идентификатор магазина и секретный ключ
@@ -32,7 +46,7 @@ func main() {
     // Создаем обработчик настроек
     settingsHandler := yookassa.NewSettingsHandler(yooclient)
     // Получаем информацию о настройках магазина или шлюза
-    settings, _ := settingsHandler.GetAccountSettings(nil)
+    settings, _ := settingsHandler.GetAccountSettings(context.Background(), nil)
 }
 ```
 В результате мы увидим примерно следующее:

--- a/docs/examples/02-payments.en.md
+++ b/docs/examples/02-payments.en.md
@@ -21,9 +21,10 @@ The response to the request will contain the `Payment` object with the current s
 
 ```go
 import (
+	"context"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa/common"
-	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 	// Create a payment handler
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Create a payment
-	payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
+	payment, _ := paymentHandler.CreatePayment(context.Background(), &yoopayment.Payment{
 		Amount: &yoocommon.Amount{
 			Value:    "1000.00",
 			Currency: "RUB",
@@ -65,8 +66,9 @@ The response to the request will contain the `Payment` object with the current s
 
 ```go
 import (
+	"context"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
-	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -75,7 +77,7 @@ func main() {
 	// Create a payment handler
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Create a payment
-	payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
+	payment, _ := paymentHandler.CreatePayment(context.Background(), &yoopayment.Payment{
 		Amount: &yoopayment.Amount{
 			Value:    "1000.00",
 			Currency: "RUB",
@@ -92,7 +94,7 @@ func main() {
 	time.Sleep(time.Second * 30)
 	
 	// We confirm the payment
-	payment, _ = paymentHandler.CapturePayment(payment)
+	payment, _ = paymentHandler.CapturePayment(context.Background(), payment)
 }
 ```
 [Learn more about confirming and canceling payments](https://yookassa.ru/developers/payment-acceptance/getting-started/payment-process?lang=en#capture-and-cancel)
@@ -112,8 +114,9 @@ If the payment was made using other payment methods, the process can take up to 
 The response to the request will contain the `Payment` object with the current status.
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+    yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -122,7 +125,7 @@ func main() {
     // Create a payment handler
     paymentHandler := yookassa.NewPaymentHandler(yooclient)
     // Create a payment
-    payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
+    payment, _ := paymentHandler.CreatePayment(context.Background(), &yoopayment.Payment{
         Amount: &yoopayment.Amount{
             Value:    "1000.00",
             Currency: "RUB",
@@ -139,7 +142,7 @@ func main() {
     time.Sleep(time.Second * 30)
     
     // Cancel payment
-    payment, _ = paymentHandler.CancelPayment(payment.ID)
+    payment, _ = paymentHandler.CancelPayment(context.Background(), payment.ID)
 }
 ```
 [Learn more about confirming and canceling payments](https://yookassa.ru/developers/payments/payment-process?lang=en#capture-and-cancel)
@@ -157,7 +160,11 @@ The response to the request will contain the `Payment` object with the current s
 ```go
 package main
 
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+	"context"
+
+	"github.com/rvinnie/yookassa-sdk-go/yookassa"
+)
 
 func main() {
 	// Create a yookassa client by specifying the store ID and secret key
@@ -165,7 +172,7 @@ func main() {
 	// Create a payment handler
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Getting payment information
-	p, _ := paymentHandler.FindPayment("21b23b5b-000f-5061-a000-0674e49a8c10")
+	p, _ := paymentHandler.FindPayment(context.Background(), "21b23b5b-000f-5061-a000-0674e49a8c10")
 }
 ```
 ---
@@ -187,8 +194,9 @@ with a `cursor` to the next fragment.
 package main
 
 import (
+	"context"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
-	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -200,7 +208,7 @@ func main() {
 	//  Get all 'succeeded' payments of 3 per request
 	var cursor string
 	for {
-		paymentsBatch, _ := paymentHandler.FindPayments(&yoopayment.PaymentListFilter{
+		paymentsBatch, _ := paymentHandler.FindPayments(context.Background(), &yoopayment.PaymentListFilter{
 			Limit:  3,
 			Cursor: cursor,
 			Status: yoopayment.Succeeded,

--- a/docs/examples/02-payments.md
+++ b/docs/examples/02-payments.md
@@ -21,8 +21,9 @@ SDK позволяет создавать, подтверждать, отмен�
 
 ```go
 import (
+	"context"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
-	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	// Создаем обработчик платежей
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Создаем платеж
-	payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
+	payment, _ := paymentHandler.CreatePayment(context.Background(), &yoopayment.Payment{
 		Amount: &yoopayment.Amount{
 			Value:    "1000.00",
 			Currency: "RUB",
@@ -63,8 +64,9 @@ func main() {
 
 ```go
 import (
+	"context"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
-	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -73,7 +75,7 @@ func main() {
 	// Создаем обработчик платежей
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Создаем платеж
-	payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
+	payment, _ := paymentHandler.CreatePayment(context.Background(), &yoopayment.Payment{
 		Amount: &yoopayment.Amount{
 			Value:    "1000.00",
 			Currency: "RUB",
@@ -90,7 +92,7 @@ func main() {
 	time.Sleep(time.Second * 30)
 	
 	// Подтверждаем платеж
-	payment, _ = paymentHandler.CapturePayment(payment)
+	payment, _ = paymentHandler.CapturePayment(context.Background(), payment)
 }
 ```
 [Подробнее о подтверждении и отмене платежей](https://yookassa.ru/developers/payments/payment-process#capture-and-cancel)
@@ -107,8 +109,9 @@ func main() {
 В ответ на запрос придет объект платежа в актуальном статусе.
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+    yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -117,7 +120,7 @@ func main() {
     // Создаем обработчик платежей
     paymentHandler := yookassa.NewPaymentHandler(yooclient)
     // Создаем платеж
-    payment, _ := paymentHandler.CreatePayment(&yoopayment.Payment{
+    payment, _ := paymentHandler.CreatePayment(context.Background(), &yoopayment.Payment{
         Amount: &yoopayment.Amount{
             Value:    "1000.00",
             Currency: "RUB",
@@ -134,7 +137,7 @@ func main() {
     time.Sleep(time.Second * 30)
     
     // Отменяем платеж
-    payment, _ = paymentHandler.CancelPayment(payment.ID)
+    payment, _ = paymentHandler.CancelPayment(context.Background(), payment.ID)
 }
 ```
 [Подробнее о подтверждении и отмене платежей](https://yookassa.ru/developers/payments/payment-process#capture-and-cancel)
@@ -152,7 +155,11 @@ func main() {
 ```go
 package main
 
-import "github.com/rvinnie/yookassa-sdk-go/yookassa"
+import (
+	"context"
+
+	"github.com/rvinnie/yookassa-sdk-go/yookassa"
+)
 
 func main() {
 	// Создаем yookassa клиента, указав идентификатор магазина и секретный ключ
@@ -160,7 +167,7 @@ func main() {
 	// Создаем обработчик платежей
 	paymentHandler := yookassa.NewPaymentHandler(yooclient)
 	// Получаем информацию о платеже
-	p, _ := paymentHandler.FindPayment("21b23b5b-000f-5061-a000-0674e49a8c10")
+	p, _ := paymentHandler.FindPayment(context.Background(), "21b23b5b-000f-5061-a000-0674e49a8c10")
 }
 ```
 ---
@@ -181,8 +188,9 @@ func main() {
 package main
 
 import (
+	"context"
 	"github.com/rvinnie/yookassa-sdk-go/yookassa"
-	"github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
 func main() {
@@ -194,7 +202,7 @@ func main() {
 	//  Получаем все 'succeeded' платежи по 3 штуки за запрос
 	var cursor string
 	for {
-		paymentsBatch, _ := paymentHandler.FindPayments(&yoopayment.PaymentListFilter{
+		paymentsBatch, _ := paymentHandler.FindPayments(context.Background(), &yoopayment.PaymentListFilter{
 			Limit:  3,
 			Cursor: cursor,
 			Status: yoopayment.Succeeded,

--- a/docs/examples/03-refunds.en.md
+++ b/docs/examples/03-refunds.en.md
@@ -23,17 +23,18 @@ In response to the request, the `Refund` object will come in the current status.
 
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
+    yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
 )
 
 func main() {
     // Create a yookassa client by specifying the store ID and secret key
     yooclient := yookassa.NewClient('<Store ID>', '<Secret key>')
     // Create a refund handler
-    refundHandler := yookassa.NewRefundHandler(client)
+    refundHandler := yookassa.NewRefundHandler(yooclient)
     // Create a refund
-    refund, err := refundHandler.CreateRefund(&yoorefund.Refund{
+    refund, err := refundHandler.CreateRefund(context.Background(), &yoorefund.Refund{
         PaymentId: "2c79414f-000f-5100-9000-1d082dd142ea",
         Amount: &yoocommon.Amount{
             Value:    "123",
@@ -56,17 +57,18 @@ In response to the request, the `Refund` object will come in the current status.
 
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
+    yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
 )
 
 func main() {
     // Create a yookassa client by specifying the store ID and secret key
     yooclient := yookassa.NewClient('<Store ID>', '<Secret key>')
     // Create a refund handler 
-    refundHandler := yookassa.NewRefundHandler(client)
+    refundHandler := yookassa.NewRefundHandler(yooclient)
     // Get the refund object
-    refund, _ := refundHandler.FindRefund("2c87b72c-0015-5000-9000-172b6038152a")
+    refund, _ := refundHandler.FindRefund(context.Background(), "2c87b72c-0015-5000-9000-172b6038152a")
 }
 ```
 
@@ -86,17 +88,18 @@ the list fragment and the `next_cursor` parameter with a pointer to the next fra
 
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
+    yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
 )
 
 func main() {
     // Create a yookassa client by specifying the store ID and secret key
     yooclient := yookassa.NewClient('<Store ID>', '<Secret key>')
     // Create a refund handler 
-    refundHandler := yookassa.NewRefundHandler(client)
+    refundHandler := yookassa.NewRefundHandler(yooclient)
     // We get a list of payment objects (the last 3 with the status succeeded)
-    refunds, err := refundHandler.FindRefunds(&yoorefund.RefundListFilter{
+    refunds, err := refundHandler.FindRefunds(context.Background(), &yoorefund.RefundListFilter{
         Status: yoorefund.Succeeded,
         Limit:  3,
     })

--- a/docs/examples/03-refunds.md
+++ b/docs/examples/03-refunds.md
@@ -23,17 +23,18 @@
 
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
+    yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
 )
 
 func main() {
     // Создаем yookassa клиента, указав идентификатор магазина и секретный ключ
     yooclient := yookassa.NewClient('<Store ID>', '<Secret key>')
     // Создаем обработчик возвратов
-    refundHandler := yookassa.NewRefundHandler(client)
+    refundHandler := yookassa.NewRefundHandler(yooclient)
     // Создаем возврат
-    refund, err := refundHandler.CreateRefund(&yoorefund.Refund{
+    refund, err := refundHandler.CreateRefund(context.Background(), &yoorefund.Refund{
         PaymentId: "2c79414f-000f-5100-9000-1d082dd142ea",
         Amount: &yoocommon.Amount{
             Value:    "123",
@@ -56,17 +57,18 @@ func main() {
 
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
+    yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
 )
 
 func main() {
     // Создаем yookassa клиента, указав идентификатор магазина и секретный ключ
     yooclient := yookassa.NewClient('<Store ID>', '<Secret key>')
     // Создаем обработчик возвратов 
-    refundHandler := yookassa.NewRefundHandler(client)
+    refundHandler := yookassa.NewRefundHandler(yooclient)
     // Получаем объект возврата
-    refund, _ := refundHandler.FindRefund("2c87b72c-0015-5000-9000-172b6038152a")
+    refund, _ := refundHandler.FindRefund(context.Background(), "2c87b72c-0015-5000-9000-172b6038152a")
 }
 ```
 
@@ -86,17 +88,18 @@ func main() {
 
 ```go
 import (
+	"context"
     "github.com/rvinnie/yookassa-sdk-go/yookassa"
-    "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
+    yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
 )
 
 func main() {
     // Создаем yookassa клиента, указав идентификатор магазина и секретный ключ
     yooclient := yookassa.NewClient('<Store ID>', '<Secret key>')
     // Создаем обработчик возвратов 
-    refundHandler := yookassa.NewRefundHandler(client)
+    refundHandler := yookassa.NewRefundHandler(yooclient)
     // Получаем список объектов возврата (последние 3 со статусом succeeded)
-    refunds, err := refundHandler.FindRefunds(&yoorefund.RefundListFilter{
+    refunds, err := refundHandler.FindRefunds(context.Background(), &yoorefund.RefundListFilter{
         Status: yoorefund.Succeeded,
         Limit:  3,
     })

--- a/yookassa/client_test.go
+++ b/yookassa/client_test.go
@@ -1,0 +1,38 @@
+package yookassa
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
+)
+
+func TestNewClientSetsDefaultTimeout(t *testing.T) {
+	client := NewClient("account_id", "secret_key")
+	httpClient, ok := client.client.(*http.Client)
+	if !ok {
+		t.Fatalf("unexpected client type: %T", client.client)
+	}
+
+	if httpClient.Timeout != defaultHTTPTimeout {
+		t.Fatalf("unexpected default timeout: %s", httpClient.Timeout)
+	}
+
+	if httpClient.Timeout <= 0 {
+		t.Fatal("expected positive default timeout")
+	}
+}
+
+func TestNewClientUsesProvidedHTTPClient(t *testing.T) {
+	custom := http.Client{Timeout: 5 * time.Second}
+	client := NewClient("account_id", "secret_key", yooopts.WithHTTPClient(custom))
+	httpClient, ok := client.client.(*http.Client)
+	if !ok {
+		t.Fatalf("unexpected client type: %T", client.client)
+	}
+
+	if httpClient.Timeout != custom.Timeout {
+		t.Fatalf("unexpected custom timeout: %s", httpClient.Timeout)
+	}
+}

--- a/yookassa/errors/error.go
+++ b/yookassa/errors/error.go
@@ -6,6 +6,8 @@ import (
 	"io"
 )
 
+const maxErrorBodyBytes = 1 << 20 // 1 MiB
+
 type YoomoneyError struct {
 	Type        string `json:"type,omitempty"`
 	Id          string `json:"id,omitempty"`
@@ -19,7 +21,7 @@ func (y *YoomoneyError) Error() string {
 }
 
 func GetError(r io.Reader) (*YoomoneyError, error) {
-	responseBytes, err := io.ReadAll(r)
+	responseBytes, err := io.ReadAll(io.LimitReader(r, maxErrorBodyBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/yookassa/errors/error_test.go
+++ b/yookassa/errors/error_test.go
@@ -1,0 +1,20 @@
+package yooerrors
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetErrorLimitsResponseBodySize(t *testing.T) {
+	payload := strings.Repeat(" ", maxErrorBodyBytes+1) +
+		`{"type":"error","id":"error-id","code":"invalid_request","description":"bad request"}`
+
+	result, err := GetError(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Code != "unexpected" {
+		t.Fatalf("expected fallback code for oversized body, got: %s", result.Code)
+	}
+}

--- a/yookassa/opts/options.go
+++ b/yookassa/opts/options.go
@@ -1,0 +1,27 @@
+package opts
+
+import "net/http"
+
+// Config is a mutable options container consumed by yookassa.NewClient.
+type Config struct {
+	Client *http.Client
+}
+
+// Option configures yookassa client creation.
+type Option interface {
+	Apply(config *Config)
+}
+
+type optionFunc func(config *Config)
+
+func (f optionFunc) Apply(config *Config) {
+	f(config)
+}
+
+// WithHTTPClient overrides default http.Client used by SDK client.
+func WithHTTPClient(client http.Client) Option {
+	return optionFunc(func(config *Config) {
+		copied := client
+		config.Client = &copied
+	})
+}

--- a/yookassa/path_escape_test.go
+++ b/yookassa/path_escape_test.go
@@ -1,0 +1,120 @@
+package yookassa
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
+	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
+)
+
+func newClientWithPathAssertion(
+	t *testing.T,
+	expectedMethod string,
+	expectedEscapedPath string,
+	responseBody string,
+) *Client {
+	t.Helper()
+
+	httpClient := http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != expectedMethod {
+				t.Fatalf("unexpected method: %s", req.Method)
+			}
+			if req.URL.EscapedPath() != expectedEscapedPath {
+				t.Fatalf("unexpected escaped path: %s", req.URL.EscapedPath())
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(responseBody)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	return NewClient("account_id", "secret_key", yooopts.WithHTTPClient(httpClient))
+}
+
+func TestCapturePaymentEscapesPaymentIDInPath(t *testing.T) {
+	paymentID := "payment/id?test"
+	client := newClientWithPathAssertion(
+		t,
+		http.MethodPost,
+		"/v3/payments/payment%2Fid%3Ftest/capture",
+		`{"id":"payment-id","status":"pending"}`,
+	)
+	handler := NewPaymentHandler(client)
+
+	_, err := handler.CapturePayment(context.Background(), &yoopayment.Payment{ID: paymentID})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestCancelPaymentEscapesPaymentIDInPath(t *testing.T) {
+	paymentID := "payment/id?test"
+	client := newClientWithPathAssertion(
+		t,
+		http.MethodPost,
+		"/v3/payments/payment%2Fid%3Ftest/cancel",
+		`{"id":"payment-id","status":"pending"}`,
+	)
+	handler := NewPaymentHandler(client)
+
+	_, err := handler.CancelPayment(context.Background(), paymentID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestFindPaymentEscapesPaymentIDInPath(t *testing.T) {
+	paymentID := "payment/id?test"
+	client := newClientWithPathAssertion(
+		t,
+		http.MethodGet,
+		"/v3/payments/payment%2Fid%3Ftest",
+		`{"id":"payment-id","status":"pending"}`,
+	)
+	handler := NewPaymentHandler(client)
+
+	_, err := handler.FindPayment(context.Background(), paymentID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestFindRefundEscapesRefundIDInPath(t *testing.T) {
+	refundID := "refund/id?test"
+	client := newClientWithPathAssertion(
+		t,
+		http.MethodGet,
+		"/v3/refunds/refund%2Fid%3Ftest",
+		`{"id":"refund-id","status":"pending"}`,
+	)
+	handler := NewRefundHandler(client)
+
+	_, err := handler.FindRefund(context.Background(), refundID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestGetPayoutEscapesPayoutIDInPath(t *testing.T) {
+	payoutID := "payout/id?test"
+	client := newClientWithPathAssertion(
+		t,
+		http.MethodGet,
+		"/v3/payouts/payout%2Fid%3Ftest",
+		`{"id":"payout-id","status":"pending"}`,
+	)
+	handler := NewPayoutHandler(client)
+
+	_, err := handler.GetPayout(context.Background(), payoutID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}

--- a/yookassa/payments.go
+++ b/yookassa/payments.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	yooerror "github.com/rvinnie/yookassa-sdk-go/yookassa/errors"
 	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
@@ -42,7 +43,7 @@ func (p *PaymentHandler) CapturePayment(ctx context.Context, payment *yoopayment
 		return nil, err
 	}
 
-	captureRequest := fmt.Sprintf("%s/%s/%s", PaymentEndpoint, payment.ID, CaptureEndpoint)
+	captureRequest := fmt.Sprintf("%s/%s/%s", PaymentEndpoint, url.PathEscape(payment.ID), CaptureEndpoint)
 
 	resp, err := p.client.MakeRequest(
 		ctx,
@@ -78,7 +79,7 @@ func (p *PaymentHandler) CapturePayment(ctx context.Context, payment *yoopayment
 
 // CancelPayment cancel payment by ID.
 func (p *PaymentHandler) CancelPayment(ctx context.Context, paymentId string) (*yoopayment.Payment, error) {
-	cancelRequest := fmt.Sprintf("%s/%s/%s", PaymentEndpoint, paymentId, CancelEndpoint)
+	cancelRequest := fmt.Sprintf("%s/%s/%s", PaymentEndpoint, url.PathEscape(paymentId), CancelEndpoint)
 
 	resp, err := p.client.MakeRequest(ctx, http.MethodPost, cancelRequest, nil, nil, p.idempotencyKey)
 	if err != nil {
@@ -160,7 +161,7 @@ func (p *PaymentHandler) CreatePaymentLink(ctx context.Context, payment *yoopaym
 
 // FindPayment find a payment by ID returns the Payment entity.
 func (p *PaymentHandler) FindPayment(ctx context.Context, id string) (*yoopayment.Payment, error) {
-	endpoint := fmt.Sprintf("%s/%s", PaymentEndpoint, id)
+	endpoint := fmt.Sprintf("%s/%s", PaymentEndpoint, url.PathEscape(id))
 
 	resp, err := p.client.MakeRequest(ctx, http.MethodGet, endpoint, nil, nil, p.idempotencyKey)
 	if err != nil {

--- a/yookassa/payments_test.go
+++ b/yookassa/payments_test.go
@@ -1,11 +1,13 @@
 package yookassa
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	yooopts "github.com/rvinnie/yookassa-sdk-go/yookassa/opts"
 	yoopayment "github.com/rvinnie/yookassa-sdk-go/yookassa/payment"
 )
 
@@ -15,25 +17,119 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func newPaymentHandlerWithResponse(statusCode int, body string) *PaymentHandler {
-	client := NewClient("account_id", "secret_key")
-	client.client = http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: statusCode,
-				Body:       io.NopCloser(strings.NewReader(body)),
-				Header:     make(http.Header),
-			}, nil
-		}),
-	}
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackingReadCloser) Close() error {
+	t.closed = true
+
+	return nil
+}
+
+func newPaymentHandlerWithRoundTrip(rt roundTripFunc) *PaymentHandler {
+	httpClient := http.Client{Transport: rt}
+	client := NewClient("account_id", "secret_key", yooopts.WithHTTPClient(httpClient))
 
 	return NewPaymentHandler(client)
+}
+
+func newPaymentHandlerWithResponse(statusCode int, body string) *PaymentHandler {
+	return newPaymentHandlerWithRoundTrip(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	}))
+}
+
+func TestCreatePaymentClosesResponseBodyOnSuccess(t *testing.T) {
+	var responseBody *trackingReadCloser
+	handler := newPaymentHandlerWithRoundTrip(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		responseBody = &trackingReadCloser{
+			Reader: strings.NewReader(
+				`{"id":"payment-id","status":"pending","confirmation":{"type":"redirect","confirmation_url":"https://example.com"}}`,
+			),
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       responseBody,
+			Header:     make(http.Header),
+		}, nil
+	}))
+
+	_, err := handler.CreatePayment(context.Background(), &yoopayment.Payment{})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if responseBody == nil || !responseBody.closed {
+		t.Fatal("expected response body to be closed")
+	}
+}
+
+func TestCreatePaymentClosesResponseBodyOnError(t *testing.T) {
+	var responseBody *trackingReadCloser
+	handler := newPaymentHandlerWithRoundTrip(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		responseBody = &trackingReadCloser{
+			Reader: strings.NewReader(
+				`{"type":"error","id":"error-id","code":"invalid_request","description":"bad request"}`,
+			),
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       responseBody,
+			Header:     make(http.Header),
+		}, nil
+	}))
+
+	_, err := handler.CreatePayment(context.Background(), &yoopayment.Payment{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if responseBody == nil || !responseBody.closed {
+		t.Fatal("expected response body to be closed")
+	}
+}
+
+func TestCreatePaymentReturnsErrorWhenBodyExceedsLimit(t *testing.T) {
+	oversizedResponse := strings.Repeat(" ", maxResponseBodyBytes+1) +
+		`{"id":"payment-id","status":"pending","confirmation":{"type":"redirect","confirmation_url":"https://example.com"}}`
+	handler := newPaymentHandlerWithResponse(http.StatusOK, oversizedResponse)
+
+	_, err := handler.CreatePayment(context.Background(), &yoopayment.Payment{})
+	if err == nil {
+		t.Fatal("expected error for oversized response body, got nil")
+	}
+}
+
+func TestParsePaymentLinkReturnsErrorForUnexpectedConfirmationType(t *testing.T) {
+	handler := NewPaymentHandler(nil)
+
+	_, err := handler.ParsePaymentLink(&yoopayment.Payment{
+		Confirmation: yoopayment.Redirect{
+			Type:            yoopayment.TypeRedirect,
+			ConfirmationURL: "https://example.com",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if err.Error() != "unable to get link" {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestCreatePaymentReturnsErrorWhenConfirmationIsEmptyAndPaymentMethodIDIsEmpty(t *testing.T) {
 	handler := newPaymentHandlerWithResponse(http.StatusOK, `{"id":"payment-id","status":"pending"}`)
 
-	_, err := handler.CreatePayment(&yoopayment.Payment{})
+	_, err := handler.CreatePayment(context.Background(), &yoopayment.Payment{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -46,7 +142,7 @@ func TestCreatePaymentReturnsErrorWhenConfirmationIsEmptyAndPaymentMethodIDIsEmp
 func TestCreatePaymentDoesNotReturnErrorWhenConfirmationIsEmptyAndPaymentMethodIDIsSet(t *testing.T) {
 	handler := newPaymentHandlerWithResponse(http.StatusOK, `{"id":"payment-id","status":"pending"}`)
 
-	result, err := handler.CreatePayment(&yoopayment.Payment{PaymentMethodID: "pm-123"})
+	result, err := handler.CreatePayment(context.Background(), &yoopayment.Payment{PaymentMethodID: "pm-123"})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/yookassa/payouts.go
+++ b/yookassa/payouts.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/url"
 
 	yooerror "github.com/rvinnie/yookassa-sdk-go/yookassa/errors"
 	yoopayout "github.com/rvinnie/yookassa-sdk-go/yookassa/payout"
@@ -98,7 +99,7 @@ func (p *PayoutHandler) CreatePayout(ctx context.Context, payout *yoopayout.Payo
 }
 
 func (p *PayoutHandler) GetPayout(ctx context.Context, payoutId string) (*yoopayout.Payout, error) {
-	endpoint := PayoutsEndpoint + "/" + payoutId
+	endpoint := PayoutsEndpoint + "/" + url.PathEscape(payoutId)
 	resp, err := p.client.MakeRequest(ctx, "GET", endpoint, nil, nil, p.idempotencyKey)
 	if err != nil {
 		return nil, err

--- a/yookassa/refunds.go
+++ b/yookassa/refunds.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	yooerror "github.com/rvinnie/yookassa-sdk-go/yookassa/errors"
 	yoorefund "github.com/rvinnie/yookassa-sdk-go/yookassa/refund"
@@ -74,7 +75,7 @@ func (r *RefundHandler) CreateRefund(ctx context.Context, refund *yoorefund.Refu
 
 // FindRefund find a refund by ID returns the Refund entity.
 func (r *RefundHandler) FindRefund(ctx context.Context, id string) (*yoorefund.Refund, error) {
-	endpoint := fmt.Sprintf("%s/%s", RefundEndpoint, id)
+	endpoint := fmt.Sprintf("%s/%s", RefundEndpoint, url.PathEscape(id))
 
 	resp, err := r.client.MakeRequest(ctx, http.MethodGet, endpoint, nil, nil, r.idempotencyKey)
 	if err != nil {


### PR DESCRIPTION
## Description
This PR introduces a breaking API refactor plus security hardening across the SDK.

### Main changes

- Added `context.Context` to all public handler methods and propagated it to HTTP requests.
- Switched handlers to interface-based dependency (`Requester`) instead of concrete `*Client`.
- Extended client configuration with options:
  - `NewClient(accountId, secretKey, options ...opts.Option)`
  - `opts.WithHTTPClient(http.Client)`

### Security and stability improvements

- Added default HTTP timeout for internal client.
- Ensured `resp.Body` is closed in all request paths.
- Added response size limits for normal/error payloads.
- Replaced unsafe type assertion in `ParsePaymentLink` with checked assertions.
- **Fixed path-segment injection risk** by escaping IDs with `url.PathEscape(...)` in:
  - `CapturePayment`
  - `CancelPayment`
  - `FindPayment`
  - `FindRefund`
  - `GetPayout`

### Tests

- Added/updated regression tests for:
  - body close behavior,
  - oversized payload handling,
  - safe confirmation parsing,
  - default/custom HTTP client behavior,
  - error body limits,
  - **escaped URL path for IDs** (`path_escape_test.go`).

### Docs

- Updated RU/EN docs and examples (`README*`, `docs/examples/01-03*`) to:
  - use `context.Background()` in handler calls,
  - use `opts.WithHTTPClient(...)`,
  - reflect current API signatures.

### Breaking changes

- Handler methods now require `context.Context`.
- Client construction now supports options and docs/examples use `WithHTTPClient`.

### Validation

- `go test ./...` passes.
